### PR TITLE
bump python GH action version

### DIFF
--- a/.github/workflows/test_tests.yaml
+++ b/.github/workflows/test_tests.yaml
@@ -49,7 +49,7 @@ jobs:
         path: tests
 
     - name: Set up Python ${{ matrix.python-version }}
-      uses: actions/setup-python@v4
+      uses: actions/setup-python@v5
       with:
         python-version: ${{ matrix.python-version }}
 


### PR DESCRIPTION
`actions/setup-python@v4` uses a deprecated version of Node, bump to v5