### PR TITLE
Show stdout on failure

### DIFF
--- a/test_framework/regalloc.py
+++ b/test_framework/regalloc.py
@@ -183,8 +183,8 @@ class TestRegAlloc(basic.TestChapter):
             len(spill_instructions),
             max_spilled_instructions,
             msg=common.build_msg(
-                f"Should only need {max_spilled_instructions} instructions \
-                    involving spilled pseudo but found {len(spill_instructions)}",
+                f"Should only need {max_spilled_instructions} instructions "
+                "involving spilled pseudo but found {len(spill_instructions)}",
                 bad_instructions=spill_instructions,
                 full_prog=parsed_asm,
                 program_path=program_path,
@@ -203,8 +203,8 @@ class TestRegAlloc(basic.TestChapter):
             len(spilled_operands),
             max_spilled_pseudos,
             msg=common.build_msg(
-                f"At most {max_spilled_pseudos} pseudoregs should have been spilled, \
-                    looks like {len(spilled_operands)} were",
+                f"At most {max_spilled_pseudos} pseudoregs should have been spilled, "
+                "looks like {len(spilled_operands)} were",
                 bad_instructions=spill_instructions,
                 full_prog=parsed_asm,
                 program_path=program_path,

--- a/test_framework/tacky/common.py
+++ b/test_framework/tacky/common.py
@@ -159,6 +159,7 @@ def build_msg(
     bad_instructions: Optional[Sequence[asm.AsmItem]] = None,
     full_prog: Optional[asm.AssemblyFunction] = None,
     program_path: Optional[Path] = None,
+    max_prog_disp_length: int = 20,
 ) -> str:
     """Utility function for validators to report invalid assembly code"""
     msg_lines = [msg]
@@ -167,7 +168,10 @@ def build_msg(
         msg_lines.append("Bad instructions:")
         msg_lines.extend(printed_instructions)
     if full_prog:
-        msg_lines.extend(["Complete program:", str(full_prog)])
+        if len(full_prog.instructions) > max_prog_disp_length:
+            msg_lines.append("Complete assembly function: <too long, not shown>")
+        else:
+            msg_lines.extend(["Complete assembly function:", str(full_prog)])
     if program_path:
         msg_lines.append(f"Program: {program_path}")
     return "\n".join(msg_lines)

--- a/test_framework/tacky/copy_prop.py
+++ b/test_framework/tacky/copy_prop.py
@@ -275,8 +275,8 @@ class TestCopyProp(common.TackyOptimizationTest):
         )
         self.assertTrue(
             same_value,
-            msg=f"Bad arguments {actual_args[0]} and {actual_args[1]} to callee: \
-                both args should have same value",
+            msg=f"Bad arguments {actual_args[0]} and {actual_args[1]} to callee: "
+            "both args should have same value",
         )
 
     def redundant_copies_test(self, program: Path) -> None:


### PR DESCRIPTION
A handful of improvement to the tests script's output on failure:
1. If return code and stdout are both incorrect, print both of them instead of just return code (fixes #20)
2. Use difflib to print difference between expected and actual stdout
3. For optimization tests, print entire assembly function only if it's below a certain length threshold (default 20 instructions). Printing the whole function is useful if it's quite short (as it is for most Chapter 19 tests) but unwieldy if it's very long (as it is for most chapter 20 tests)
4. Cleaned up some bad whitespace in optimization test output

