### PR TITLE
Cleaner failure reports

### DIFF
--- a/test_framework/basic.py
+++ b/test_framework/basic.py
@@ -338,7 +338,7 @@ class TestChapter(unittest.TestCase):
         """
         result: subprocess.CompletedProcess[str]
         with self.assertRaises(
-            subprocess.CalledProcessError, msg=f"Didn't catch error in {source_file}"
+            subprocess.CalledProcessError, msg=f"Didn't catch error in '{source_file.relative_to(TEST_DIR)}'"
         ):
             result = self.invoke_compiler(source_file)
             result.check_returncode()  # raise CalledProcessError if return code is non-zero

--- a/test_framework/runner.py
+++ b/test_framework/runner.py
@@ -6,6 +6,7 @@ import argparse
 import itertools
 import platform
 import subprocess
+import sys
 import unittest
 import warnings
 from functools import reduce
@@ -445,6 +446,9 @@ def main() -> int:
         return 1
 
     compiler = Path(args.cc).resolve()
+
+    if args.verbose == 0:
+        sys.tracebacklimit = 0
 
     # merge list of extra-credit features into bitvector
 


### PR DESCRIPTION
- **print relative-to-test-dir path to failing source file**
- **disable tracebacks overall when verbosity is off**
