### PR TITLE
pass full ref to test_each_chapter so we can check out forks correctly

### DIFF
--- a/.github/workflows/test_all_commits.yaml
+++ b/.github/workflows/test_all_commits.yaml
@@ -11,5 +11,5 @@ jobs:
   test_all_chapters:
     uses: nlsandler/nqcc2/.github/workflows/test_each_chapter.yaml@extra-credit
     with:
-      tests-branch: ${{ github.head_ref }}
+      tests-branch: ${{ github.ref }}
       cc-branch: extra-credit


### PR DESCRIPTION
Let's see if this fixes the CI failure in https://github.com/nlsandler/writing-a-c-compiler-tests/pull/64