### PR TITLE
Test from workflow fix

### DIFF
--- a/.github/workflows/test_all_commits.yaml
+++ b/.github/workflows/test_all_commits.yaml
@@ -11,5 +11,5 @@ jobs:
   test_all_chapters:
     uses: nlsandler/nqcc2/.github/workflows/test_each_chapter.yaml@extra-credit
     with:
-      tests-branch: ${{ github.head_ref }}
+      tests-branch: ${{ github.ref }}
       cc-branch: extra-credit

--- a/README.md
+++ b/README.md
@@ -1,3 +1,5 @@
+here is a change
+
 # Writing a C Compiler Test Suite
 
 The test suite for the upcoming book [Writing a C Compiler](https://nostarch.com/writing-c-compiler), a hands-on guide to writing your own compiler for a big chunk of C. These tests are still a work in progress!


### PR DESCRIPTION
The purpose of this change is to test whether the fix in fix-gh-workflow actually lets us run CI against pull requests from forks. (Must target main instead of fix-gh-workflow to trigger workflow run)