### PR TITLE
In comments, fix typos.

### DIFF
--- a/tests/chapter_12/valid/explicit_casts/chained_casts.c
+++ b/tests/chapter_12/valid/explicit_casts/chained_casts.c
@@ -7,7 +7,7 @@ int main(void) {
 
 
     /* In this case we
-     * 1. convert ui to a signed int by computing 2^32 - ui, producing -96
+     * 1. convert ui to a signed int by computing ui - 2^32, producing -96
      * 2. signed-extend the result, which preserves the value of -96
      * Note that if we cast ui directly to a signed long, its value wouldn't change
      */
@@ -15,7 +15,7 @@ int main(void) {
         return 1;
 
     /* In this case we
-     * 1. convert ui to a signed int by computing 2^32 - ui, producing -96
+     * 1. convert ui to a signed int by computing ui - 2^32, producing -96
      * 2. convert this signed int to an unsigned long by computing -96 + 2^64
      * Note that if we converted ui directly to an unsigned long, its value
      * wouldn't change

--- a/tests/chapter_13/valid/extra_credit/compound_assign_implicit_cast.c
+++ b/tests/chapter_13/valid/extra_credit/compound_assign_implicit_cast.c
@@ -9,7 +9,7 @@ int main(void) {
     }
 
     unsigned long ul = 18446744073709551586ul;
-    /* We'll promote e to the nearest double,
+    /* We'll promote ul to the nearest double,
      * which is 18446744073709551616,
      * then subtract 1.5 * 10^19, which
      * results in 3446744073709551616.0,

--- a/tests/chapter_13/valid/special_values/subnormal_not_zero.c
+++ b/tests/chapter_13/valid/special_values/subnormal_not_zero.c
@@ -11,7 +11,7 @@ int main(void) {
     /* Make sure subnormal numbers are not rounded to zero */
     double subnormal = 2.5e-320;
 
-    /* Perform an operation on a subnroaml number to produce a normal number */
+    /* Perform an operation on a subnormal number to produce a normal number */
     if (multiply_by_large_num(subnormal) != 4.99994433591341498562e-300) {
         return 2;
     }

--- a/tests/chapter_14/valid/extra_credit/compound_assign_conversion.c
+++ b/tests/chapter_14/valid/extra_credit/compound_assign_conversion.c
@@ -1,4 +1,4 @@
-// Test comound assignment through pointers that require type conversions
+// Test compound assignment through pointers that require type conversions
 
 int main(void) {
     // lval is pointer
@@ -11,7 +11,7 @@ int main(void) {
     }
     int i = -50;
     int *i_ptr = &i;
-    // convert *i_ptr to unsigned, perform conversion, then convert back
+    // convert *i_ptr to unsigned, perform operation, then convert back
     *i_ptr %= 4294967200U;
     if (*i_ptr != 46) {
         return 2; // fail

--- a/tests/chapter_14/valid/extra_credit/compound_assign_conversion.c
+++ b/tests/chapter_14/valid/extra_credit/compound_assign_conversion.c
@@ -1,4 +1,4 @@
-// Test comound assignment through pointers that requires type conversions
+// Test comound assignment through pointers that require type conversions
 
 int main(void) {
     // lval is pointer
@@ -11,7 +11,7 @@ int main(void) {
     }
     int i = -50;
     int *i_ptr = &i;
-    // convert i_ptr to unsigned, perform conversion, then convert back
+    // convert *i_ptr to unsigned, perform conversion, then convert back
     *i_ptr %= 4294967200U;
     if (*i_ptr != 46) {
         return 2; // fail

--- a/tests/chapter_14/valid/extra_credit/compound_assign_conversion.c
+++ b/tests/chapter_14/valid/extra_credit/compound_assign_conversion.c
@@ -1,4 +1,4 @@
-// Test compound assignment through pointers that require type conversions
+// Test compound assignment through pointers involving type conversions
 
 int main(void) {
     // lval is pointer
@@ -16,7 +16,6 @@ int main(void) {
     if (*i_ptr != 46) {
         return 2; // fail
     }
-
 
     // rval is pointer
     unsigned int ui = 4294967295U; // 2^32 - 1

--- a/tests/chapter_15/valid/extra_credit/compound_assign_to_nested_subscript.c
+++ b/tests/chapter_15/valid/extra_credit/compound_assign_to_nested_subscript.c
@@ -32,7 +32,7 @@ int main(void) {
         return 4;  // fail
     }
 
-    // make sure the other elemnts of dbl_nested_array are unchanged
+    // make sure the other elemnts of dbl_nested_arr are unchanged
     for (int i = 0; i < 3; i += 1) {
         for (int j = 0; j < 2; j += 1) {
             if (i == 1 && j == 1) {

--- a/tests/chapter_15/valid/extra_credit/compound_assign_to_nested_subscript.c
+++ b/tests/chapter_15/valid/extra_credit/compound_assign_to_nested_subscript.c
@@ -32,7 +32,7 @@ int main(void) {
         return 4;  // fail
     }
 
-    // make sure the other elemnts of dbl_nested_arr are unchanged
+    // make sure the other elements of dbl_nested_arr are unchanged
     for (int i = 0; i < 3; i += 1) {
         for (int j = 0; j < 2; j += 1) {
             if (i == 1 && j == 1) {

--- a/tests/chapter_15/valid/initialization/automatic_nested.c
+++ b/tests/chapter_15/valid/initialization/automatic_nested.c
@@ -91,7 +91,7 @@ int test_preserve_stack(void) {
     /* Initialize with expressions of long type - make sure they're truncated
      * before being copied into the array.
      * Also use an array of < 16 bytes so it's not 16-byte aligned, so there are
-     * eightbytes that include both array elements and other values.
+     * eight bytes that include both array elements and other values.
      * Also leave last element uninitialized; in assembly, we should set it to
      * zero without overwriting what follows
      */

--- a/tests/chapter_15/valid/initialization/automatic_nested.c
+++ b/tests/chapter_15/valid/initialization/automatic_nested.c
@@ -91,7 +91,7 @@ int test_preserve_stack(void) {
     /* Initialize with expressions of long type - make sure they're truncated
      * before being copied into the array.
      * Also use an array of < 16 bytes so it's not 16-byte aligned, so there are
-     * eight bytes that include both array elements and other values.
+     * quadwords that include both array elements and other values.
      * Also leave last element uninitialized; in assembly, we should set it to
      * zero without overwriting what follows
      */

--- a/tests/chapter_2/valid/bitwise_int_min.c
+++ b/tests/chapter_2/valid/bitwise_int_min.c
@@ -1,5 +1,5 @@
 int main(void) {
-    // take the bitwise complement of the smallest int we can construct righ tnow
+    // take the bitwise complement of the smallest int we can construct right now
     // (minimum representable int is actually -2147483648, but we can't
     // construct it b/c the constant 2147483648 is out of bounds)
     return ~-2147483647;


### PR DESCRIPTION
This PR modifies intra-sample comments only.

One thing I left untouched: in `tests/chapter_10/valid/libraries/external_linkage_function_client.c`, `add_three_and_four()`, comment says the `sum()` function is shadowed, but it's not.