### PR TITLE
make external linkage case test what it claims to test

### DIFF
--- a/tests/chapter_10/valid/libraries/external_linkage_function_client.c
+++ b/tests/chapter_10/valid/libraries/external_linkage_function_client.c
@@ -19,8 +19,9 @@ int sum(int x, int y);
 
 
 int add_three_and_four(void) {
-    int f = 3;
-    if (f > 2) {
+    /* Define a sum variable shadowing the sum function */
+    int sum = 3;
+    if (sum > 2) {
         /* The extern keyword can bring a shadowed
          * function identifier back into scope
          */


### PR DESCRIPTION
Fix issue flagged by @ysono in #87 where `sum` function wasn't actually shadowed in `add_three_and_four`