### PR TITLE
Fix find_reaching_copies for asm call with @PLT

### DIFF
--- a/test_framework/parser/parse.py
+++ b/test_framework/parser/parse.py
@@ -393,7 +393,8 @@ def parse_operand(toks: List[Token]) -> tuple[Operand, Optional[int]]:
         and toks[2].tok_type == TokType.SYMBOL
     ):
         # it's a function name with a relocation, e.g. foo@PLT
-        target = f"{toks[0].tok_str}@{toks[2].tok_str}"
+        # we don't need the relocation symbol, keep only the function name
+        target = toks[0].tok_str
         # consume all tokens from list
         toks.clear()
         return (target, None)

--- a/test_framework/test_tests/test_parse.py
+++ b/test_framework/test_tests/test_parse.py
@@ -225,7 +225,7 @@ main:
                 Instruction(Opcode.CALL, ["_foo12_3"]),
                 Instruction(Opcode.CALL, ["f_"]),
                 Instruction(Opcode.CALL, ["__"]),
-                Instruction(Opcode.CALL, ["f@PLT"]),
+                Instruction(Opcode.CALL, ["f"]),
             ],
         )
         self.assertExpectedAssembly(asm, expected_assembly)


### PR DESCRIPTION
On Linux, the copy propagation tester doesn't find asm `call` instruction when using the suffix <name>@PLT.
Fix: If the asm call is not found on Linux, append @PLT to the first arg (function name) and try again.