### PR TITLE
Windows support: fix filepaths in the get_props_key function; use ctypes for handling a return code as uint8

### DIFF
--- a/test_compiler.py
+++ b/test_compiler.py
@@ -1,0 +1,12 @@
+#!/usr/bin/env python3
+# -*- coding: utf-8 -*-
+
+import sys
+
+if sys.version_info < (3, 8):
+    sys.exit("This script requires Python version 3.8 or later")
+
+import test_framework.runner
+
+if __name__ == "__main__":
+    sys.exit(test_framework.runner.main())

--- a/test_framework/basic.py
+++ b/test_framework/basic.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import ctypes
 import difflib
 import json
 import platform
@@ -63,7 +64,7 @@ def get_props_key(source_file: Path) -> str:
     """
     if source_file.stem.endswith("_client"):
         source_file = replace_stem(source_file, source_file.stem[: -len("_client")])
-    return str(source_file.relative_to(TEST_DIR))
+    return str(source_file.relative_to(TEST_DIR)).replace("\\", "/")
 
 
 def needs_mathlib(prog: Path) -> bool:
@@ -307,7 +308,7 @@ class TestChapter(unittest.TestCase):
         exe = actual.args[0]
         self.assertEqual(
             expected_retcode,
-            actual.returncode,
+            ctypes.c_uint8(actual.returncode).value,
             msg=build_error_message(expected_retcode, expected_stdout, actual, exe),
         )
         self.assertEqual(
@@ -555,7 +556,6 @@ def excluded_extra_credit(source_prog: Path, extra_credit_flags: ExtraCredit) ->
     Returns:
         true if we should _exclude_ this program from test run, false if we should include it.
     """
-
     if "extra_credit" not in source_prog.parts:
         # this isn't an extra-credit test so we shouldn't exclude it
         return False


### PR DESCRIPTION
Hello Nora,

I am reading your wonderful book and writing a compiler on Windows using GitBash and gcc. I have fixed the test framework a bit so it can run on my machine:
```bash
python test_compiler.py path/to/compiler --chapter N
```
Perhaps someone else will find it useful.