### PR TITLE
--ignore flag to ignore specific tests

### DIFF
--- a/test_framework/runner.py
+++ b/test_framework/runner.py
@@ -108,6 +108,14 @@ def parse_arguments() -> argparse.Namespace:
         help="Only run valid test programs (useful when testing backend changes)",
     )
     parser.add_argument(
+        "--ignore",
+        type=str,
+        help=(
+            "A comma-separated list of tests to ignore, e.g. "
+            "chapter_1/invalid_parse/missing_type.c,chapter_2/valid/neg.c"
+        )
+    )
+    parser.add_argument(
         "--failfast", "-f", action="store_true", help="Stop on first test failure"
     )
     parser.add_argument("--verbose", "-v", action="count", default=0)
@@ -487,6 +495,7 @@ def main() -> int:
                 extra_credit_flags=extra_credit,
                 skip_invalid=args.skip_invalid,
                 error_codes=args.expected_error_codes,
+                ignore_list=(args.ignore or "").split(','),
             )
             test_instance = unittest.defaultTestLoader.loadTestsFromTestCase(test_class)
             test_suite.addTest(test_instance)


### PR DESCRIPTION
This PR implements support for ignoring specific tests.

This is specified as a comma-separated list of the last three path components of the `.c` files to be ignored, e.g.:

```
$ ./test_compiler mycc --chapter 1 --ignore chapter_1/invalid_parse/missing_type.c,chapter_1/valid/tabs.c
```

I'd like to integrate the verbosity flag into this (to indicate that a test was ignored), but I'm not sure how to do that yet.

(My particular use-case is that I am using pycparser for the front-end, and it doesn't fail on chapter_1/invalid_parse/missing_type.c)

Let me know what you think!