### PR TITLE
Use consistent capitalization in arguments

### DIFF
--- a/test_framework/regalloc.py
+++ b/test_framework/regalloc.py
@@ -113,7 +113,7 @@ class TestRegAlloc(basic.TestChapter):
 
         # first compile to assembly
         try:
-            self.invoke_compiler(program_path, cc_opt="-s").check_returncode()
+            self.invoke_compiler(program_path, cc_opt="-S").check_returncode()
         except subprocess.CalledProcessError as e:
             self.fail(f"Compilation failed:\n{e.stderr}")
         asm_file = program_path.with_suffix(".s")

--- a/test_framework/tacky/common.py
+++ b/test_framework/tacky/common.py
@@ -49,7 +49,7 @@ class TackyOptimizationTest(basic.TestChapter):
         """
 
         # first compile to assembly
-        compile_result = self.invoke_compiler(source_file, cc_opt="-s")
+        compile_result = self.invoke_compiler(source_file, cc_opt="-S")
         self.assertEqual(
             compile_result.returncode,
             0,


### PR DESCRIPTION
Currently, the `-S` flag is passed either as `-s` or as `-S`, which causes problems for drivers using case-sensitive arguments. I've opted here for `-S` to match gcc and the capitalization presented in the book.