### PR TITLE
Fix one single typo in a comment (ineger -> integer)

### DIFF
--- a/tests/chapter_16/valid/chars/integer_promotion.c
+++ b/tests/chapter_16/valid/chars/integer_promotion.c
@@ -42,7 +42,7 @@ int main(void) {
     }
 
     unsigned char one = 1;
-    // because of ineger promotion, this won't wrap around to 255
+    // because of integer promotion, this won't wrap around to 255
     if (negate(one) != -1) {
         return 2;
     }


### PR DESCRIPTION
In `tests/chapter_16/valid/chars/integer_promotion.c` a comment says "ineger promotion" instead of "integer promotion".