### PR TITLE
Return unique values in arithmetic_ops.c

### DIFF
--- a/tests/chapter_13/valid/floating_expressions/arithmetic_ops.c
+++ b/tests/chapter_13/valid/floating_expressions/arithmetic_ops.c
@@ -64,7 +64,7 @@ int main(void) {
     }
 
     if (!complex_expression()) {
-        return 5;
+        return 6;
     }
 
     return 0;


### PR DESCRIPTION
Currently, `!negation()` and `!complex_expression()` both result in returning the same value, `5`. 

This changes the return value for `!complex_expression()` to `6` so that failures are unambiguous. 